### PR TITLE
Предложение по ExcelReportsProcessor

### DIFF
--- a/java/org/echosoft/framework/reports/processor/ExcelReportProcessor.java
+++ b/java/org/echosoft/framework/reports/processor/ExcelReportProcessor.java
@@ -73,15 +73,6 @@ public class ExcelReportProcessor {
     private static final String MACROS = "$M=";
     private static final int MACROS_LENGTH = MACROS.length();
 
-    private static final ExcelReportProcessor instance = new ExcelReportProcessor();
-
-    public static ExcelReportProcessor getInstance() {
-        return instance;
-    }
-
-    private ExcelReportProcessor() {
-    }
-
     /**
      * Формирует отчет на основании его модели и указанных пользователем в контексте параметров.
      *

--- a/test/org/echosoft/framework/reports/SimpleReportTest.java
+++ b/test/org/echosoft/framework/reports/SimpleReportTest.java
@@ -48,7 +48,7 @@ public class SimpleReportTest {
         ctx.getEnvironment().put("payments", TestUtils.loadPayments("report1-ds2.xml"));
 
         final long started = System.currentTimeMillis();
-        final HSSFWorkbook result = ExcelReportProcessor.getInstance().process(report, ctx);
+        final HSSFWorkbook result = new ExcelReportProcessor().process(report, ctx);
         System.out.println("report " + report.getId() + " generated for a " + (System.currentTimeMillis() - started) + " ms.");
 
         for (int i = 0; i < result.getNumberOfSheets(); i++) {
@@ -72,7 +72,7 @@ public class SimpleReportTest {
         ctx.getEnvironment().put("toDate", StringUtil.parseDate("25.08.2008"));
         ctx.getEnvironment().put("activities", TestUtils.loadPayments("report1-ds3.xml"));
 
-        final HSSFWorkbook result = ExcelReportProcessor.getInstance().process(report, ctx);
+        final HSSFWorkbook result = new ExcelReportProcessor().process(report, ctx);
         final FileOutputStream out = new FileOutputStream("result-2.xls");
         result.write(out);
         out.close();
@@ -86,7 +86,7 @@ public class SimpleReportTest {
         ctx.getEnvironment().put("company", "Сукинъ и Сыновья");
         ctx.getEnvironment().put("activities", TestUtils.loadPayments("report1-ds3.xml"));
 
-        final HSSFWorkbook result = ExcelReportProcessor.getInstance().process(report, ctx);
+        final HSSFWorkbook result = new ExcelReportProcessor().process(report, ctx);
         final FileOutputStream out = new FileOutputStream("result-3.xls");
         result.write(out);
         out.close();


### PR DESCRIPTION
Привет.

Предлагаю сделать чтобы ExcelReportsProcessor не был синглтоном.
В том коммите у меня видимо что-то с форматом файла (переносы строк) - а так дифф простой - убрал конструктор, getInstance и поле instance из ExcelReportsProcessor и поправил тест.

Мне это потребовалось потому что надо перекрыть один метод в процессоре и добавить там нужные try/catch/throw - в библиотеку это бессмысленно коммитить. А процессор можно сделать синглтоном уже в рамках конечного проекта - это легко. 
